### PR TITLE
Update to support newer versions of laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x",
+        "illuminate/support": "4.x",
         "guzzle/guzzle": "3.7.*"
     },
     "autoload": {


### PR DESCRIPTION
Fixed dependencies to support Laravel 4.1

I have tested this to work by installing my fork via composer.
I has similar pull request for my packages a while ago https://github.com/thomaswelton/laravel-gravatar/pull/2
